### PR TITLE
Fix social provider filtering

### DIFF
--- a/app/Http/Controllers/SocialAuthController.php
+++ b/app/Http/Controllers/SocialAuthController.php
@@ -84,7 +84,7 @@ class SocialAuthController extends Controller
     private function getEnabledProviders(): array
     {
         return collect(config('app.social_providers', []))
-            ->filter(fn ($config) => $config['enabled'] == true ?? false)
+            ->filter(fn ($config) => ($config['enabled'] ?? false) === true)
             ->map(fn ($config) => ['name' => $config['name']])
             ->toArray();
     }

--- a/tests/Feature/SocialAuthProvidersTest.php
+++ b/tests/Feature/SocialAuthProvidersTest.php
@@ -1,0 +1,27 @@
+<?php
+
+test('providers endpoint returns only enabled providers', function () {
+    config(['app.social_providers' => [
+        'github' => [
+            'name' => 'GitHub',
+            // 'enabled' key intentionally missing to ensure defaults to false
+        ],
+        'google' => [
+            'enabled' => true,
+            'name' => 'Google',
+        ],
+    ]]);
+
+    $response = $this->getJson('/auth/providers');
+
+    $response->assertOk()
+        ->assertJson([
+            'providers' => [
+                'google' => ['name' => 'Google'],
+            ],
+        ]);
+
+    expect($response->json('providers'))->toHaveKey('google');
+    expect($response->json('providers'))->not->toHaveKey('github');
+});
+


### PR DESCRIPTION
## Summary
- properly handle missing `enabled` flags when determining available social providers
- add test for providers endpoint to ensure only enabled providers are returned

## Testing
- `composer test` *(fails: require(/workspace/core/vendor/autoload.php): No such file or directory)*
- `composer install` *(fails: curl error 56 while downloading https://api.github.com/...: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a0eb1511908323b16e71ea5627bb25