### PR TITLE
fix: guard against missing provider avatars

### DIFF
--- a/app/Actions/UpdateUserAvatarAction.php
+++ b/app/Actions/UpdateUserAvatarAction.php
@@ -21,8 +21,10 @@ class UpdateUserAvatarAction
             ->orderBy('last_login_at', 'desc')
             ->first();
 
-        $avatarUrl = $latestAccount?->provider_avatar_url;
+        if (! $latestAccount) {
+            return $user;
+        }
 
-        return $this->execute($user, $avatarUrl);
+        return $this->execute($user, $latestAccount->provider_avatar_url);
     }
 }

--- a/tests/Unit/Actions/UpdateUserAvatarActionTest.php
+++ b/tests/Unit/Actions/UpdateUserAvatarActionTest.php
@@ -35,13 +35,15 @@ class UpdateUserAvatarActionTest extends TestCase
         $this->assertNull($user->fresh()->avatar_url);
     }
 
-    public function test_update_to_latest_provider_avatar_with_no_accounts(): void
+    public function test_update_to_latest_provider_avatar_with_no_accounts_keeps_existing_avatar(): void
     {
-        $user = User::factory()->create(['avatar_url' => 'https://old-avatar.com/image.jpg']);
+        $avatarUrl = 'https://old-avatar.com/image.jpg';
+        $user = User::factory()->create(['avatar_url' => $avatarUrl]);
         $action = new UpdateUserAvatarAction;
 
         $updatedUser = $action->updateToLatestProviderAvatar($user);
 
-        $this->assertNull($updatedUser->avatar_url);
+        $this->assertEquals($avatarUrl, $updatedUser->avatar_url);
+        $this->assertEquals($avatarUrl, $user->fresh()->avatar_url);
     }
 }


### PR DESCRIPTION
## Summary
- avoid clearing avatar when no provider avatars exist
- test that existing avatar persists without social accounts

## Testing
- `composer test` *(fails: require(/workspace/core/vendor/autoload.php): Failed to open stream: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a0ed4348b88323842c5adba61f5eb9