### PR TITLE
refactor: use Hash and Str for random password

### DIFF
--- a/app/Actions/Social/LinkSocialAccountAction.php
+++ b/app/Actions/Social/LinkSocialAccountAction.php
@@ -6,6 +6,8 @@ use App\Actions\User\UpdateUserAvatarAction;
 use App\Exceptions\SocialAuthException;
 use App\Models\SocialAccount;
 use App\Models\User;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Str;
 
 class LinkSocialAccountAction
 {
@@ -67,7 +69,7 @@ class LinkSocialAccountAction
             'name' => $socialUser->getName() ?: $socialUser->getNickname(),
             'email' => $socialUser->getEmail(),
             'email_verified_at' => now(),
-            'password' => bcrypt(str()->random(32)), // Random password
+            'password' => Hash::make(Str::random(32)), // Random password
             'avatar_url' => $avatarUrl,
         ]);
     }


### PR DESCRIPTION
## Summary
- import Hash and Str in LinkSocialAccountAction
- use Hash::make with Str::random for new user passwords

## Testing
- `npm run lint` (warning: unsupported TypeScript version)
- `composer test` (fails: vendor/autoload.php missing)


------
https://chatgpt.com/codex/tasks/task_e_68a44e7ff3688323bfebccd85eb68b49