### PR TITLE
refactor: move auth login to RegisterUserAction

### DIFF
--- a/app/Actions/Auth/RegisterUserAction.php
+++ b/app/Actions/Auth/RegisterUserAction.php
@@ -4,6 +4,7 @@ namespace App\Actions\Auth;
 
 use App\Models\User;
 use Illuminate\Auth\Events\Registered;
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Validation\Rules\Password;
@@ -32,6 +33,8 @@ class RegisterUserAction
             'email' => $email,
             'password' => Hash::make($password),
         ]);
+
+        Auth::login($user);
 
         event(new Registered($user));
 

--- a/app/Http/Controllers/Auth/RegisteredUserController.php
+++ b/app/Http/Controllers/Auth/RegisteredUserController.php
@@ -6,7 +6,6 @@ use App\Actions\Auth\RegisterUserAction;
 use App\Http\Controllers\Controller;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Auth;
 use Illuminate\Validation\ValidationException;
 use Inertia\Inertia;
 use Inertia\Response;
@@ -28,9 +27,7 @@ class RegisteredUserController extends Controller
      */
     public function store(Request $request, RegisterUserAction $registerAction): RedirectResponse
     {
-        $user = $registerAction->execute($request->name, $request->email, $request->password);
-
-        Auth::login($user);
+        $registerAction->execute($request->name, $request->email, $request->password);
 
         return redirect(route('dashboard', absolute: false));
     }

--- a/tests/e2e/auth/login.spec.ts
+++ b/tests/e2e/auth/login.spec.ts
@@ -185,7 +185,8 @@ test.describe('Login Flow', () => {
                     status: 429,
                     contentType: 'application/json',
                     body: JSON.stringify({
-                        message: 'Too many attempts. Account temporarily locked.',
+                        message:
+                            'Too many attempts. Account temporarily locked.',
                         retry_after: 900,
                     }),
                 });


### PR DESCRIPTION
## Summary
- Moved `Auth::login($user)` from `RegisteredUserController` to `RegisterUserAction`
- Added `Auth` facade import to `RegisterUserAction`
- Removed unused `Auth` import from `RegisteredUserController`
- Improved separation of concerns by keeping authentication logic within the action

This refactor consolidates the user registration and login flow in a single action, making the code more maintainable and following the single responsibility principle.