### PR TITLE
Fix provider token column length for social accounts

### DIFF
--- a/database/migrations/2025_07_15_195854_create_social_accounts_table.php
+++ b/database/migrations/2025_07_15_195854_create_social_accounts_table.php
@@ -16,7 +16,7 @@ return new class extends Migration
             $table->foreignId('user_id')->constrained()->onDelete('cascade');
             $table->string('provider'); // google, github, facebook, etc.
             $table->string('provider_id'); // unique ID from the provider
-            $table->string('provider_token')->nullable(); // access token
+            $table->text('provider_token')->nullable(); // access token
             $table->string('provider_refresh_token')->nullable(); // refresh token
             $table->timestamp('provider_token_expires_at')->nullable();
             $table->string('provider_avatar_url')->nullable(); // avatar URL from provider


### PR DESCRIPTION
## Summary

- Updated `provider_token` column from `string()` (VARCHAR 255) to `text()` (TEXT 64KB) in social_accounts migration
- Fixes SQLSTATE[22001] error when storing OAuth tokens longer than 255 characters
- OAuth tokens from providers like Google can exceed 255 characters, requiring larger storage capacity

## Test plan

- [ ] Verify migration runs without errors
- [ ] Test social login with Google provider
- [ ] Confirm long OAuth tokens are stored successfully